### PR TITLE
fix: Redirect oomusou.io to old-oomusou.goodjack.tw

### DIFF
--- a/code/booki/book/wd106b/TypeScript.md
+++ b/code/booki/book/wd106b/TypeScript.md
@@ -1,4 +1,4 @@
 # TypeScript
-* [TypeScript 特色與歷史簡介](http://oomusou.io/typescript/intro/)
+* [TypeScript 特色與歷史簡介](https://old-oomusou.goodjack.tw/typescript/intro/)
 * https://github.com/Microsoft/TypeScript
   * [TypeScript Language Specification](https://github.com/Microsoft/TypeScript/blob/730f18955dc17068be33691f0fb0e0285ebbf9f5/doc/spec.md)


### PR DESCRIPTION
舊的 oomusou.io 文章已經轉移至 old-oomusou.goodjack.tw